### PR TITLE
Reinstate legacy friendly_id slugging behaviour

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'sdoc', '~> 0.4.0',          group: :doc
 gem 'spring',        group: :development
 
 gem 'friendly_id', '5.0.4'
+gem 'babosa', '1.0.1'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
     arel (5.0.1.20140414130214)
+    babosa (1.0.1)
     builder (3.2.2)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
@@ -110,6 +111,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  babosa (= 1.0.1)
   coffee-rails (~> 4.0.0)
   friendly_id (= 5.0.4)
   jbuilder (~> 2.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,5 +19,6 @@ module LegacyFriendlyIdBehaviour
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+    config.autoload_paths << "#{config.root}/lib"
   end
 end

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -19,7 +19,7 @@ FriendlyId.defaults do |config|
     stylesheets assets javascripts images)
 
 
-  config.use :slugged
+  config.use :slugged, FriendlyId::SequentialSlugs
   #  ## Friendly Finders
   #
   # Uncomment this to use friendly finders in all models. By default, if
@@ -58,7 +58,7 @@ FriendlyId.defaults do |config|
   # separator. If you're upgrading from FriendlyId 4, you may wish to replace this
   # with two dashes.
   #
-  config.sequence_separator = '-'
+  config.sequence_separator = '--'
   #
   #  ## Tips and Tricks
   #

--- a/lib/friendly_id/sequential_slug_generator.rb
+++ b/lib/friendly_id/sequential_slug_generator.rb
@@ -1,0 +1,53 @@
+module FriendlyId
+  class SequentialSlugGenerator
+    attr_accessor :scope, :slug, :slug_column, :sequence_separator
+
+    def initialize(scope, slug, slug_column, sequence_separator)
+      @scope = scope
+      @slug = slug
+      @slug_column = slug_column
+      @sequence_separator = sequence_separator
+    end
+
+    def generate
+      slug + sequence_separator + next_sequence_number.to_s
+    end
+
+  private
+
+    def next_sequence_number
+      if last_sequence_number == 0
+        2
+      else
+        last_sequence_number + 1
+      end
+    end
+
+    def last_sequence_number
+      slug_conflicts.last.split("#{slug}#{sequence_separator}").last.to_i
+    end
+
+    def slug_conflicts
+      scope.
+        where(conflict_query, slug, sequential_slug_matcher).
+        order(ordering_query).pluck(slug_column)
+    end
+
+    def conflict_query
+      "#{slug_column} = ? OR #{slug_column} LIKE ?"
+    end
+
+    def sequential_slug_matcher
+      # Underscores (matching a single character) and percent signs (matching
+      # any number of characters) need to be escaped
+      # (While this seems like an excessive number of backslashes, it is correct)
+      "#{slug}#{sequence_separator}".gsub(/[_%]/, '\\\\\&') + '%'
+    end
+
+    # Return the unnumbered (shortest) slug first, followed by the numbered ones
+    # in ascending order.
+    def ordering_query
+      "LENGTH(#{slug_column}) ASC, #{slug_column} ASC"
+    end
+  end
+end

--- a/lib/friendly_id/sequential_slugs.rb
+++ b/lib/friendly_id/sequential_slugs.rb
@@ -1,31 +1,52 @@
 module FriendlyId
   module SequentialSlugs
     def resolve_friendly_id_conflict(candidates)
-      candidate_slug = candidates.first
-      candidate_slug + friendly_id_config.sequence_separator + next_sequence_number(candidate_slug).to_s
+      SequentialSlugResolver.new(scope_for_slug_generator,
+                                 candidates.first,
+                                 friendly_id_config.slug_column,
+                                 friendly_id_config.sequence_separator).next_slug
+    end
+  end
+
+  class SequentialSlugResolver
+    attr_accessor :scope, :clashing_slug, :slug_column, :sequence_separator
+
+    def initialize(scope, clashing_slug, slug_column, sequence_separator)
+      @scope = scope
+      @clashing_slug = clashing_slug
+      @slug_column = slug_column
+      @sequence_separator = sequence_separator
     end
 
-    def next_sequence_number(candidate_slug)
-      slug_conflicts(candidate_slug).count + 1
-    end
-
-    def slug_conflicts(candidate_slug)
-      scope_for_slug_generator.
-        where(conflict_query, candidate_slug, sequential_slug_matcher(candidate_slug)).
-        order("LENGTH(#{friendly_id_config.slug_column}) ASC, #{friendly_id_config.slug_column} ASC")
+    def next_slug
+      clashing_slug + sequence_separator + next_sequence_number.to_s
     end
 
   private
 
-    def conflict_query
-      "#{friendly_id_config.slug_column} = ? OR #{friendly_id_config.slug_column} LIKE ?"
+    def next_sequence_number
+      slug_conflicts.count + 1
     end
 
-    def sequential_slug_matcher(candidate_slug)
+    def slug_conflicts
+      scope.
+        where(conflict_query, clashing_slug, sequential_slug_matcher).
+        order(ordering_query)
+    end
+
+    def conflict_query
+      "#{slug_column} = ? OR #{slug_column} LIKE ?"
+    end
+
+    def sequential_slug_matcher
       # Underscores (matching a single character) and percent signs (matching
       # any number of characters) need to be escaped
       # (While this seems like an excessive number of backslashes, it is correct)
-      "#{candidate_slug}#{friendly_id_config.sequence_separator}".gsub(/[_%]/, '\\\\\&') + '%'
+      "#{clashing_slug}#{sequence_separator}".gsub(/[_%]/, '\\\\\&') + '%'
+    end
+
+    def ordering_query
+      "LENGTH(#{slug_column}) ASC, #{slug_column} ASC"
     end
   end
 end

--- a/lib/friendly_id/sequential_slugs.rb
+++ b/lib/friendly_id/sequential_slugs.rb
@@ -1,0 +1,31 @@
+module FriendlyId
+  module SequentialSlugs
+    def resolve_friendly_id_conflict(candidates)
+      candidate_slug = candidates.first
+      candidate_slug + friendly_id_config.sequence_separator + next_sequence_number(candidate_slug).to_s
+    end
+
+    def next_sequence_number(candidate_slug)
+      slug_conflicts(candidate_slug).count + 1
+    end
+
+    def slug_conflicts(candidate_slug)
+      scope_for_slug_generator.
+        where(conflict_query, candidate_slug, sequential_slug_matcher(candidate_slug)).
+        order("LENGTH(#{friendly_id_config.slug_column}) ASC, #{friendly_id_config.slug_column} ASC")
+    end
+
+  private
+
+    def conflict_query
+      "#{friendly_id_config.slug_column} = ? OR #{friendly_id_config.slug_column} LIKE ?"
+    end
+
+    def sequential_slug_matcher(candidate_slug)
+      # Underscores (matching a single character) and percent signs (matching
+      # any number of characters) need to be escaped
+      # (While this seems like an excessive number of backslashes, it is correct)
+      "#{candidate_slug}#{friendly_id_config.sequence_separator}".gsub(/[_%]/, '\\\\\&') + '%'
+    end
+  end
+end

--- a/lib/friendly_id/sequential_slugs.rb
+++ b/lib/friendly_id/sequential_slugs.rb
@@ -1,60 +1,13 @@
 module FriendlyId
+  # Module that patches friendly_id to produce sequentially numbered slugs.
+  # This replicates the behaviour of v4 instead of the new default behaviour in
+  # v5, which is to append a GUID to a conflicted slug.
   module SequentialSlugs
-    def resolve_friendly_id_conflict(candidates)
-      SequentialSlugResolver.new(scope_for_slug_generator,
-                                 candidates.first,
+    def resolve_friendly_id_conflict(candidate_slugs)
+      SequentialSlugGenerator.new(scope_for_slug_generator,
+                                 candidate_slugs.first,
                                  friendly_id_config.slug_column,
-                                 friendly_id_config.sequence_separator).next_slug
-    end
-  end
-
-  class SequentialSlugResolver
-    attr_accessor :scope, :clashing_slug, :slug_column, :sequence_separator
-
-    def initialize(scope, clashing_slug, slug_column, sequence_separator)
-      @scope = scope
-      @clashing_slug = clashing_slug
-      @slug_column = slug_column
-      @sequence_separator = sequence_separator
-    end
-
-    def next_slug
-      clashing_slug + sequence_separator + next_sequence_number.to_s
-    end
-
-  private
-
-    def next_sequence_number
-      if last_sequence_number == 0
-        2
-      else
-        last_sequence_number + 1
-      end
-    end
-
-    def last_sequence_number
-      slug_conflicts.last.split("#{clashing_slug}#{sequence_separator}").last.to_i
-    end
-
-    def slug_conflicts
-      scope.
-        where(conflict_query, clashing_slug, sequential_slug_matcher).
-        order(ordering_query).pluck(slug_column)
-    end
-
-    def conflict_query
-      "#{slug_column} = ? OR #{slug_column} LIKE ?"
-    end
-
-    def sequential_slug_matcher
-      # Underscores (matching a single character) and percent signs (matching
-      # any number of characters) need to be escaped
-      # (While this seems like an excessive number of backslashes, it is correct)
-      "#{clashing_slug}#{sequence_separator}".gsub(/[_%]/, '\\\\\&') + '%'
-    end
-
-    def ordering_query
-      "LENGTH(#{slug_column}) ASC, #{slug_column} ASC"
+                                 friendly_id_config.sequence_separator).generate
     end
   end
 end

--- a/lib/friendly_id/sequential_slugs.rb
+++ b/lib/friendly_id/sequential_slugs.rb
@@ -25,13 +25,21 @@ module FriendlyId
   private
 
     def next_sequence_number
-      slug_conflicts.count + 1
+      if last_sequence_number == 0
+        2
+      else
+        last_sequence_number + 1
+      end
+    end
+
+    def last_sequence_number
+      slug_conflicts.last.split("#{clashing_slug}#{sequence_separator}").last.to_i
     end
 
     def slug_conflicts
       scope.
         where(conflict_query, clashing_slug, sequential_slug_matcher).
-        order(ordering_query)
+        order(ordering_query).pluck(slug_column)
     end
 
     def conflict_query

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -5,4 +5,20 @@ class PersonTest < ActiveSupport::TestCase
     person = Person.create!(name: 'Hayao Miyazaki')
     assert_equal 'hayao-miyazaki', person.slug
   end
+
+  test 'clashing slugs get a sequence number' do
+    people = (1..12).map { Person.create!(name: 'Hayao Miyazaki') }
+
+    assert_equal 'hayao-miyazaki', people[0].slug
+    assert_equal 'hayao-miyazaki--2', people[1].slug
+    # assert_equal 'hayao-miyazaki--3', people[2].slug
+    # assert_equal 'hayao-miyazaki--4', people[3].slug
+    # assert_equal 'hayao-miyazaki--5', people[4].slug
+    # assert_equal 'hayao-miyazaki--6', people[5].slug
+    # assert_equal 'hayao-miyazaki--7', people[6].slug
+    # assert_equal 'hayao-miyazaki--8', people[7].slug
+    # assert_equal 'hayao-miyazaki--9', people[8].slug
+    # assert_equal 'hayao-miyazaki--10', people[9].slug
+    # assert_equal 'hayao-miyazaki--11', people[10].slug
+  end
 end

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -22,4 +22,20 @@ class PersonTest < ActiveSupport::TestCase
     assert_equal 'hayao-miyazaki--11', people[10].slug
     assert_equal 'hayao-miyazaki--12', people[11].slug
   end
+
+  test 'sequential slug resolution copes with deleted instances' do
+    person_1 = Person.create!(name: 'Hayao Miyazaki')
+    person_2 = Person.create!(name: 'Hayao Miyazaki')
+    person_3 = Person.create!(name: 'Hayao Miyazaki')
+
+    assert_equal 'hayao-miyazaki', person_1.slug
+    assert_equal 'hayao-miyazaki--2', person_2.slug
+    assert_equal 'hayao-miyazaki--3', person_3.slug
+
+    person_2.destroy
+
+    person_4 = Person.create!(name: 'Hayao Miyazaki')
+
+    assert_equal 'hayao-miyazaki--4', person_4.slug
+  end
 end

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -7,20 +7,12 @@ class PersonTest < ActiveSupport::TestCase
   end
 
   test 'clashing slugs get a sequence number' do
-    people = (1..12).map { Person.create!(name: 'Hayao Miyazaki') }
+    people = (1..105).map { Person.create!(name: 'Hayao Miyazaki') }
 
     assert_equal 'hayao-miyazaki', people[0].slug
-    assert_equal 'hayao-miyazaki--2', people[1].slug
-    assert_equal 'hayao-miyazaki--3', people[2].slug
-    assert_equal 'hayao-miyazaki--4', people[3].slug
-    assert_equal 'hayao-miyazaki--5', people[4].slug
-    assert_equal 'hayao-miyazaki--6', people[5].slug
-    assert_equal 'hayao-miyazaki--7', people[6].slug
-    assert_equal 'hayao-miyazaki--8', people[7].slug
-    assert_equal 'hayao-miyazaki--9', people[8].slug
-    assert_equal 'hayao-miyazaki--10', people[9].slug
-    assert_equal 'hayao-miyazaki--11', people[10].slug
-    assert_equal 'hayao-miyazaki--12', people[11].slug
+    (1..104).each do |number|
+      assert_equal "hayao-miyazaki--#{number + 1}", people[number].slug
+    end
   end
 
   test 'sequential slug resolution copes with deleted instances' do
@@ -37,5 +29,13 @@ class PersonTest < ActiveSupport::TestCase
     person_4 = Person.create!(name: 'Hayao Miyazaki')
 
     assert_equal 'hayao-miyazaki--4', person_4.slug
+  end
+
+  test 'sequential slugging copes with candidates ending with numbers' do
+    robot_1 = Person.create!(name: 'Robot No. 12')
+    robot_2 = Person.create!(name: 'Robot No. 12')
+
+    assert_equal 'robot-no-12', robot_1.slug
+    assert_equal 'robot-no-12--2', robot_2.slug
   end
 end

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -11,14 +11,15 @@ class PersonTest < ActiveSupport::TestCase
 
     assert_equal 'hayao-miyazaki', people[0].slug
     assert_equal 'hayao-miyazaki--2', people[1].slug
-    # assert_equal 'hayao-miyazaki--3', people[2].slug
-    # assert_equal 'hayao-miyazaki--4', people[3].slug
-    # assert_equal 'hayao-miyazaki--5', people[4].slug
-    # assert_equal 'hayao-miyazaki--6', people[5].slug
-    # assert_equal 'hayao-miyazaki--7', people[6].slug
-    # assert_equal 'hayao-miyazaki--8', people[7].slug
-    # assert_equal 'hayao-miyazaki--9', people[8].slug
-    # assert_equal 'hayao-miyazaki--10', people[9].slug
-    # assert_equal 'hayao-miyazaki--11', people[10].slug
+    assert_equal 'hayao-miyazaki--3', people[2].slug
+    assert_equal 'hayao-miyazaki--4', people[3].slug
+    assert_equal 'hayao-miyazaki--5', people[4].slug
+    assert_equal 'hayao-miyazaki--6', people[5].slug
+    assert_equal 'hayao-miyazaki--7', people[6].slug
+    assert_equal 'hayao-miyazaki--8', people[7].slug
+    assert_equal 'hayao-miyazaki--9', people[8].slug
+    assert_equal 'hayao-miyazaki--10', people[9].slug
+    assert_equal 'hayao-miyazaki--11', people[10].slug
+    assert_equal 'hayao-miyazaki--12', people[11].slug
   end
 end

--- a/test/models/pet_test.rb
+++ b/test/models/pet_test.rb
@@ -1,4 +1,17 @@
 require 'test_helper'
 
 class PetTest < ActiveSupport::TestCase
+  test 'allows duplicate slugs outside the scope' do
+    person_1  = Person.create!(name: 'Ismail')
+    rambo_1 = Pet.create!(name: 'Rambo', owner: person_1)
+    rambo_2 = Pet.create!(name: 'Rambo', owner: person_1)
+
+    person_2  = Person.create!(name: 'Frank')
+    rambo_3 = Pet.create!(name: 'Rambo', owner: person_2)
+
+    assert_equal 'rambo', rambo_1.slug
+    assert_equal 'rambo--2', rambo_2.slug
+
+    assert_equal 'rambo', rambo_3.slug
+  end
 end


### PR DESCRIPTION
Proof-of-concept for using sequential slug numbering to resolve conflicts using friendly_id v5.

We plan to upgrade [whitehall](https://github.com/alphagov/whitehall) to Rails 4, but to do so, we also need to upgrade friendly_id to v5. Unfortunately, v5 of friendly_id behaves differently to the version we are currently using - it adds a UUID to the end of slugs that conflict with existing ones. This pull request demonstrates how friendly_id v5 could be configured to behave like v4 and generate sequentially-numbered slugs when resolving slug conflicts. This will allow us to upgrade whitehall to Rails 4 whilst still maintaining the existing slugging behaviour.
